### PR TITLE
fixed missing arguments in readme examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ out to a PNG file:
 
 (write-png
   (->img
-    (draw-solid
+    #(draw-solid
       {:focal-length 3
        :color-fn (wireframe :white :transparent)
        :style :transparent
@@ -113,7 +113,7 @@ out to a PNG file:
                     (rotate :z (degrees->radians 65))
                     (rotate :y (degrees->radians -30))
                     (translate 0 0 16))
-       :shape (make-torus 1 3 60 60)})
+       :shape (make-torus 1 3 60 60)} %)
     [400 400])
   "torus-65.png")
 ```
@@ -141,12 +141,12 @@ MATLAB-style function plots can be generated thus:
         1.0
         (/ (Math/sin x) x)))
 
-(defn mexican-hat [x y]
+(defn sombrero [x y]
   (* 15 (sinc (Math/sqrt (+ (sqr x) (sqr y ))))))
 
 (write-png
   (->img
-    (draw-solid
+    #(draw-solid
       {:focal-length 30
        :color-fn (comp
                    black-edge                         ; [1]
@@ -162,7 +162,7 @@ MATLAB-style function plots can be generated thus:
        :shape (make-surface                           ; [4]
                 (range -22 22 0.25)
                 (range -22 22 0.25)
-                mexican-hat)})                        ; [5]
+                sombrero)} %)                        ; [5]
     [600 600])
   "sinc3D.png")
 ```
@@ -186,7 +186,7 @@ code sample:
 
 (write-png
   (->img
-    (draw-solid
+    #(draw-solid
       {:focal-length 10
        :fill-color Color/WHITE
        :style :translucent
@@ -194,7 +194,7 @@ code sample:
                     (rotate :z (degrees->radians 35))
                     (rotate :x (degrees->radians -70))
                     (translate 0 -1 40))
-       :shape (load-shape "resources/newell-teapot/teapot")})
+       :shape (load-shape "resources/newell-teapot/teapot")} %)
     [1000 900])
   "teapot.png")
 ```


### PR DESCRIPTION
The calls to 'draw-solid were missing their 'g2d arguments, so I altered each s-exp to an anon fn so 
'->img would thread them properly.

Changed 'mexican-hat to 'sombrero, which is more precise/concise. fwiw, 'sombrero technically means "hat with brim" but it's still a more precise shorthand for 'sombrero-charro which is what it's called in Mexico.

If you have any feedback, or I shouldn't have changed those fns like that, please let me know. I feel comfortable with clojure, but I still have so much to learn.

By the way, this library is wonderful. I've been having a lot of fun with it so far, and I really appreciate the work you've put into it. If you need any help with anything, I'd love to pitch in.
